### PR TITLE
Output parsing refactor

### DIFF
--- a/hermitd/DEVELOPMENT.md
+++ b/hermitd/DEVELOPMENT.md
@@ -13,7 +13,7 @@ Or you can run `OPENAI_API_KEY=xxx python3 hermitd -c hermitd.conf.remote.sample
 ## Style
 Remember to run `source format.sh` before commits.
 
-Then run `flake8 hermitd tests` to lint your code.
+Then run `source check.sh` to lint your code.
 
 ## Builds
 First install the latest version of `pip install --upgrade build`

--- a/hermitd/check.sh
+++ b/hermitd/check.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+source format.sh --check
+flake8 hermitd tests

--- a/hermitd/hermitd/context.py
+++ b/hermitd/hermitd/context.py
@@ -1,5 +1,6 @@
 from hermitd.messages import ShellOutputType
 import textwrap
+from typing import Optional
 
 
 IGNORED_TYPES = {ShellOutputType.Header}
@@ -22,12 +23,19 @@ class Context:
     def __init__(self) -> None:
         self.shell_ctx: list[list[(ShellOutputType, str)]] = []
         self.current_dialogue: list[(ShellOutputType, str)] = []
+        self.undecided_stack: list[str] = []
 
-    def save_shell_context(self, data_type: ShellOutputType, data: str):
+    def save_shell_context(self, data_type: Optional[ShellOutputType], data: str):
         if data_type in IGNORED_TYPES:
+            self.undecided_stack = []
             return
 
-        self.current_dialogue.append((data_type, data))
+        self.undecided_stack.append(data)
+        if data_type is None:
+            return
+
+        self.current_dialogue.append((data_type, "".join(self.undecided_stack)))
+        self.undecided_stack = []
 
         if data_type == ShellOutputType.Output:
             # each time we have an output, that marks the end of a "dialogue"

--- a/hermitd/hermitd/messages.py
+++ b/hermitd/hermitd/messages.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Literal, Final
+from typing import Final, Literal, Optional
 from pydantic import BaseModel
 
 API_VERSION: Final[str] = "0.1a"
@@ -43,7 +43,7 @@ class SaveContext(HermitRequest):
     type: Literal["SaveContext"]
     session_id: int
     context: str
-    context_type: ShellOutputType
+    context_type: Optional[ShellOutputType]
 
 
 # Responses

--- a/hermitd/tests/test_context.py
+++ b/hermitd/tests/test_context.py
@@ -1,5 +1,5 @@
 import pytest
-from hermitd.context import Context
+from hermitd.context import Context, TRUNCATED_MARKER
 from hermitd.messages import ShellOutputType
 
 
@@ -46,6 +46,50 @@ from hermitd.messages import ShellOutputType
 )
 def test_save_shell_context(input, expected_output):
     ctx = Context()
+    for data_type, data in input:
+        ctx.save_shell_context(data_type, data)
+
+    assert ctx._get_shell_ctx() == expected_output
+
+
+@pytest.mark.parametrize(
+    "input, expected_output",
+    [
+        (
+            [
+                (None, "0"),
+                (None, "1"),
+                (None, "2"),
+                (None, "3"),
+                (ShellOutputType.Input, "input"),
+            ],
+            [
+                [(ShellOutputType.Input, f"012{TRUNCATED_MARKER}input")],
+            ],
+        ),
+        (
+            [
+                (None, "01234567"),
+                (ShellOutputType.Input, "input"),
+            ],
+            [
+                [(ShellOutputType.Input, f"012{TRUNCATED_MARKER}input")],
+            ],
+        ),
+        (
+            [
+                (None, "012"),
+                (ShellOutputType.Input, "input"),
+            ],
+            [
+                [(ShellOutputType.Input, "012input")],
+            ],
+        ),
+    ],
+)
+def test_save_shell_context_truncation(input, expected_output):
+    ctx = Context(max_chunk_length=3)
+
     for data_type, data in input:
         ctx.save_shell_context(data_type, data)
 

--- a/hermitd/tests/test_context.py
+++ b/hermitd/tests/test_context.py
@@ -30,6 +30,18 @@ from hermitd.messages import ShellOutputType
                 [(ShellOutputType.Input, "3")],
             ],
         ),
+        (
+            [
+                (None, "0"),
+                (ShellOutputType.Input, "1"),
+                (None, "0"),
+                (ShellOutputType.Output, "2"),
+                (None, "0"),
+            ],
+            [
+                [(ShellOutputType.Input, "01"), (ShellOutputType.Output, "02")],
+            ],
+        ),
     ],
 )
 def test_save_shell_context(input, expected_output):

--- a/llmsh/debug_utils.py
+++ b/llmsh/debug_utils.py
@@ -1,0 +1,6 @@
+
+def u8_to_str(vec_u8: list[int]):
+    print("".join([chr(u) for u in vec_u8]))
+
+def str_to_u8(s: str):
+    print([ord(c) for c in s])

--- a/llmsh/src/messages.rs
+++ b/llmsh/src/messages.rs
@@ -27,7 +27,8 @@ enum Request {
     },
     SaveContext {
         session_id: u32,
-        context_type: ShellOutputType,
+        // None means the context type is still undecided
+        context_type: Option<ShellOutputType>,
         context: String,
     },
     Exit {
@@ -152,7 +153,7 @@ impl HermitdClient {
 
     pub fn save_context(
         &self,
-        context_type: ShellOutputType,
+        context_type: Option<ShellOutputType>,
         context: String,
     ) -> Result<(), util::Error> {
         let save_request = Request::SaveContext {


### PR DESCRIPTION
Refactored output parsing. The changes in this PR include:
1. No longer aggregates the undecided characters within the BufferParser, instead sends to hermitd to aggregate
2. Fixed the BufferParser transition bug, where if there are multiple matching transitions, it used to match based on the order the transitions were defined, whereas now it transitions based on the position within the input buffer the first match occurs. (When multiple transitions match at the exact starting position, currently it's undefined behavior, still matching based on order of transition defined.)
3. Implemented aggregation in llmsh only when echos happen in input state. This reduces ipc calls to hermitd. (Otherwise we do 1 ipc to per character user types...)
4. Implemented truncation in hermitd, if the aggregation exceeds a certain size, context is no longer saved. (This saves resources)

After these changes, we performance improved by more than 10x. A simple test is to use:
```bash
time python3 -c 'print("abcdefg\n" * 100000)'
```
Results are measured for both *10^4 and *10^5.

|    | 10^4 | 10^5 |
| --- | --- | --- |
| bash  | ~0.02s    | ~0.4s |
| llmsh (before) | 1.256s    | 3m25.752s |
| llmsh (after)    | ~0.3s | ~4.5s |

As shown, now the time taken on larger outputs scale relatively stably, more on the order of `O(n)`, in line with bash's performance. `llmsh` is still roughly 10x slower than bash, but this is somewhat expected, since it runs on top of bash, and we re-process every IO coming from bash.